### PR TITLE
Fix running composer as root

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,6 @@ wordpress_webroot: "{{sites_dir}}/{{site_name}}/www"
 wordpress_cookiehub: false
 wordpress_cookiehub_repo: git@gitlab.com:libraries-fi/wp-cookiehub-plugin.git
 wordpress_cookiehub_version: 5d1c2a2e206e7b093e1c3b383875c51949a6dc86
-wordpress_cookiehub_dest: "{{sites_dir}}/{{site_name}}/web/app/plugins/kifi-cookiehub/"
+wordpress_cookiehub_dest: "{{sites_dir}}/{{site_name}}/web/app/plugins/kifi-cookiehub"
+wordpress_yoast: false
+wordpress_yoast_token: ""

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,8 @@
   shell: >
     composer install --prefer-source --no-interaction
     chdir={{ wordpress_site_dir }}
+  environment:
+    COMPOSER_ALLOW_SUPERUSER: 1
   when: wordpress_bedrock is defined
 
 - name: Copy files in place

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,9 +20,18 @@
     version: "{{ synced_wordpress.branch|default('master') }}"
   when: synced_wordpress.repo is defined
 
+- name: Setup token for Yoast Composer repository
+  shell: "composer config http-basic.my.yoast.com token {{ wordpress_yoast_token }}"
+  environment:
+    COMPOSER_ALLOW_SUPERUSER: 1
+  args:
+    chdir: "{{ sites_dir }}/{{ site_name }}"
+  when: wordpress_yoast
+  tags: composer
+
 - name: Install dependencies with Composer.
   shell: >
-    composer install --prefer-source --no-interaction
+    composer install --no-interaction
     chdir={{ wordpress_site_dir }}
   environment:
     COMPOSER_ALLOW_SUPERUSER: 1
@@ -53,6 +62,11 @@
             - "../templates"
           skip: yes
   when: wordpress_config_template is defined
+
+- name: Configure cookiehub plugin path for git
+  shell: "git config --global --add safe.directory {{ wordpress_cookiehub_dest }}"
+  when: wordpress_cookiehub
+  tags: cookiehub
 
 - name: Get cookiehub plugin
   git:


### PR DESCRIPTION
Add a fix to allow Composer to run plugins even when run as root like this role does and cherry-pick parts of https://github.com/libraries-fi/ansible-role-wordpress/pull/8 not yet merged.