### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 # file: kirjasampo/tasks/main.yml
 
-- include: install.yml
-- include: setup-wordpress-permissions.yml
+- include_tasks: install.yml
+- include_tasks: setup-wordpress-permissions.yml


### PR DESCRIPTION
Change deprecated include to include_tasks in main.yml of tasks. Works with both ansible-core 2.11.12 and 2.19.2.